### PR TITLE
Upgrade org.apache.zookeeper:zookeeper to version 3.4.14

### DIFF
--- a/zookeeper-lab/build.gradle
+++ b/zookeeper-lab/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.apache.zookeeper', name: 'zookeeper', version: '3.4.12'
+    compile group: 'org.apache.zookeeper', name: 'zookeeper', version: '3.4.14'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 


### PR DESCRIPTION
Moderate severity security issue.

An issue is present in Apache ZooKeeper 1.0.0 to 3.4.13 and 3.5.0-alpha to 3.5.4-beta. ZooKeeper's getACL() command doesn't check any permission when retrieves the ACLs of the requested node and returns all information contained in the ACL Id field as plaintext string. DigestAuthenticationProvider overloads the Id field with the hash value that is used for user authentication. As a consequence, if Digest Authentication is in use, the unsalted hash value will be disclosed by getACL() request for unauthenticated or unprivileged users.